### PR TITLE
Update FileSaver.js

### DIFF
--- a/manual_deidentification/interactive_de-identifying_tool/js/FileSaver.js
+++ b/manual_deidentification/interactive_de-identifying_tool/js/FileSaver.js
@@ -75,7 +75,7 @@ var saveAs = saveAs || (function(view) {
 		}
 		, FileSaver = function(blob, name, no_auto_bom) {
 			if (!no_auto_bom) {
-				blob = auto_bom(blob);
+				//blob = auto_bom(blob);
 			}
 			// First try a.download, then web filesystem, then object URLs
 			var
@@ -149,7 +149,7 @@ var saveAs = saveAs || (function(view) {
 			name = name || blob.name || "download";
 
 			if (!no_auto_bom) {
-				blob = auto_bom(blob);
+				//blob = auto_bom(blob);
 			}
 			return navigator.msSaveOrOpenBlob(blob, name);
 		};


### PR DESCRIPTION
Commented out two places where the auto_bom function is called. Now, the deid tool should no longer add BOM encoding to files.
Note: I didn't use the deid-improvement branch since I don't have write access to it yet.